### PR TITLE
ci: wrong directory for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: gitsubmodule
     schedule:
         interval: "daily"
-    directory: "/themes"
+    directory: "/"


### PR DESCRIPTION
Although the `/themes` directory is where the git submodule is stored, the `.gitmodules` file is in the root directory. Dependabot needs to know where this file is located.